### PR TITLE
Added jQuery CDN fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 
     <link rel="stylesheet" href="style.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="https://code.jquery.com/jquery-1.6.1.min.js"><\/script>')</script>
     <script src="js/jquery.json-2.3.min.js"></script>
     <script src="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.9.4/jquery.dataTables.min.js"></script>
     <script src="js/jquery.ba-hashchange.js"></script>


### PR DESCRIPTION
Added jQuery CDN fallback. Useful for many reasons including making site work in China where Google's CDN is reportedly blocked.
